### PR TITLE
Fix #5, Prevent command injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ coverage
 
 # Benchmarking
 benchmarks/graphs
+
+# IntelliJ
+.idea/
+*.iml

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,19 @@ import AwsTerraformRouterV1 from './v1/terraform/Aws';
 // Init router and path
 const router = Router();
 
+router.use((req, res, next) => {
+    const { access_key, secret_key } = req.headers;
+    if (typeof access_key === 'string' && !access_key.match(/^[A-Za-z0-9]+$/)) {
+        res.status(400).end(JSON.stringify({}));
+        return;
+    }
+    if (typeof secret_key === 'string' && !secret_key.match(/^[A-Za-z0-9]+$/)) {
+        res.status(400).end(JSON.stringify({}));
+        return;
+    }
+    next();
+});
+
 // Add sub-routes
 router.use('/users', UserRouter);
 router.use('/v1/aws', AwsRouterV1)


### PR DESCRIPTION
Header의 `access_key`나 `secret_key`가 string인 경우, regex로 숫자나 영문만 사용한 문자열이 아니면 400 Bad Request를 리턴합니다.
별도의 API 문서가 정해진 것이 없는 것 같아서 오류 응답에 대한 별도의 페이로드는 넣지 않았습니다.